### PR TITLE
Update printer

### DIFF
--- a/examples/test_all/test_all.ino
+++ b/examples/test_all/test_all.ino
@@ -63,7 +63,7 @@ void setup()
 void loop()
 {
     // 気圧・温湿度計の値を取得して記録
-    bth.read().print();
+    logger.info(F("[BaroThermoHygrometer]"), bth.read());
     delay(500);
 
     // 光センサの値を取得して記録

--- a/examples/test_all/test_all.ino
+++ b/examples/test_all/test_all.ino
@@ -83,7 +83,7 @@ void loop()
     delay(500);
 
     // GPS から取得した情報を記録
-    gps.read().print();
+    logger.info(F("[GPSReceiver]"), gps.read());
     delay(500);
 
     // サーボモーターを動かす

--- a/examples/test_all/test_all.ino
+++ b/examples/test_all/test_all.ino
@@ -75,7 +75,7 @@ void loop()
     delay(500);
 
     // IMU の値を取得して記録
-    imu.read().print();
+    logger.info(F("[IMU]"), imu.read());
     delay(500);
 
     // マイクの値を取得して記録

--- a/examples/test_baro_thermo_hygrometer/test_baro_thermo_hygrometer.ino
+++ b/examples/test_baro_thermo_hygrometer/test_baro_thermo_hygrometer.ino
@@ -21,7 +21,7 @@ void setup()
 void loop()
 {
     // 気圧、温度、湿度を取得してシリアルモニタに表示
-    bth.read().print();
+    logger.info(bth.read());
 
     // 気圧を取得して変数に代入したい場合
     // float pressure = bth.read().pressure;  // [hPa]

--- a/examples/test_gps_receiver/test_gps_receiver.ino
+++ b/examples/test_gps_receiver/test_gps_receiver.ino
@@ -20,7 +20,7 @@ void setup()
 void loop()
 {
     // GPS から取得した情報をシリアルモニタに表示
-    gps.read().print();
+    logger.info(gps.read());
 
     // GPS から取得した情報を変数に代入したい場合
     // float latitude = gps.read().lat;   // 緯度 [°]

--- a/examples/test_imu/test_imu.ino
+++ b/examples/test_imu/test_imu.ino
@@ -21,7 +21,7 @@ void setup()
 void loop()
 {
     // IMU の値を取得してシリアルモニタに表示
-    imu.read().print();
+    logger.info(imu.read());
 
     // 1s 待つ
     delay(1000);
@@ -32,9 +32,9 @@ void loop()
     // auto mag = imu.readMag();    // 地磁気
 
     // 取得した値をシリアルモニタに表示
-    // print(F("Accel:"), acc.x, F(","), acc.y, F(","), acc.z);
-    // print(F("Gyro:"), gyro.x, F(","), gyro.y, F(","), gyro.z);
-    // print(F("Mag:"), mag.x, F(","), mag.y, F(","), mag.z);
+    // logger.info(F("Acc:"), acc);
+    // logger.info(F("Gyro:"), gyro);
+    // logger.info(F("Mag:"), mag);
 
     // 1s 待つ
     delay(1000);

--- a/examples/tutorial_mission_advanced/sequence.hpp
+++ b/examples/tutorial_mission_advanced/sequence.hpp
@@ -50,14 +50,14 @@ void commonTask()
 
     // 高度を取得する
     height = calculateHeightFromPressure(bth.read().pressure);
-    logger.debug(F("Height:"), height, F("[m]"));
+    logger.info(F("Height:"), height, F("[m]"));
 
     // 光センサの値を取得する
     light = cds.read();
     logger.debug(F("Light:"), light);
 
     // 位置を取得する
-    gps.read().print();
+    logger.info(gps.read());
 }
 
 void loadingTask()

--- a/src/device/baro_thermo_hygrometer.cpp
+++ b/src/device/baro_thermo_hygrometer.cpp
@@ -10,11 +10,6 @@
 namespace Device
 {
 
-    void BaroThermoHygrometer_t::print() const
-    {
-        Utility::logger.info(F("Pressure:"), pressure, F("[hPa], Temperature:"), temperature, F("[°C], Humidity:"), humidity, F("[%]"));
-    }
-
     BaroThermoHygrometer::BaroThermoHygrometer()
     {
     }

--- a/src/device/baro_thermo_hygrometer.hpp
+++ b/src/device/baro_thermo_hygrometer.hpp
@@ -12,8 +12,6 @@ namespace Device
         float pressure;     // [hPa]
         float temperature;  // [°C]
         float humidity;     // [%]
-
-        void print() const;
     };
 
     class BaroThermoHygrometer : public SensorBase<BaroThermoHygrometer_t>

--- a/src/device/gps_receiver.cpp
+++ b/src/device/gps_receiver.cpp
@@ -5,11 +5,6 @@
 namespace Device
 {
 
-    void GPS_t::print() const
-    {
-        Utility::logger.info(F("Time:"), time, F("[s], Latitude:"), lat, F("[°], Longitude:"), lon, F("[°], Altitude:"), alt, F("[m]"));
-    }
-
     GPSReceiver::GPSReceiver(uint8_t tx_pin)
         : serial_{tx_pin, 0}, is_available_{false}
     {

--- a/src/device/gps_receiver.hpp
+++ b/src/device/gps_receiver.hpp
@@ -13,8 +13,6 @@ namespace Device
         float lon;   // [°]
         float alt;   // [m]
         float time;  // [s]
-
-        void print() const;
     };
 
     class GPSReceiver : public SensorBase<GPS_t>

--- a/src/device/imu.cpp
+++ b/src/device/imu.cpp
@@ -12,16 +12,6 @@
 namespace Device
 {
 
-    void coordinate::print() const
-    {
-        Utility::logger.info("(", x, ",", y, ",", z, ")");
-    }
-
-    void IMU_t::print() const
-    {
-        Utility::logger.info("Acc: (", acc.x, ",", acc.y, ",", acc.z, "), Gyro: (", gyro.x, ",", gyro.y, ",", gyro.z, "), Mag: (", mag.x, ",", mag.y, ",", mag.z, ")");
-    }
-
     IMU::IMU()
         : accel_offset_({0.0, 0.0, 0.0}), gyro_offset_({0.0, 0.0, 0.0}), mag_offset_({0.0, 0.0, 0.0})
     {

--- a/src/device/imu.hpp
+++ b/src/device/imu.hpp
@@ -12,8 +12,6 @@ namespace Device
         float x;
         float y;
         float z;
-
-        void print() const;
     };
 
     struct IMU_t
@@ -21,8 +19,6 @@ namespace Device
         coordinate acc;
         coordinate gyro;
         coordinate mag;
-
-        void print() const;
     };
 
     class IMU : public SensorBase<IMU_t>

--- a/src/device/sd_card.cpp
+++ b/src/device/sd_card.cpp
@@ -33,4 +33,17 @@ namespace Device
         file.println(F(" [%]"));
     }
 
+    void SDCard::write_impl(File& file, GPS_t last)
+    {
+        file.print(F("Time: "));
+        file.print(last.time);
+        file.print(F(" [s], Latitude: "));
+        file.print(last.lat);
+        file.print(F(" [°], Longitude: "));
+        file.print(last.lon);
+        file.print(F(" [°], Altitude: "));
+        file.print(last.alt);
+        file.println(F(" [m]"));
+    }
+
 }  // namespace Device

--- a/src/device/sd_card.cpp
+++ b/src/device/sd_card.cpp
@@ -22,6 +22,17 @@ namespace Device
         return true;
     }
 
+    void SDCard::write_impl(File& file, coordinate last)
+    {
+        file.print(F("("));
+        file.print(last.x);
+        file.print(F(", "));
+        file.print(last.y);
+        file.print(F(", "));
+        file.print(last.z);
+        file.println(F(")"));
+    }
+
     void SDCard::write_impl(File& file, BaroThermoHygrometer_t last)
     {
         file.print(F("Pressure: "));
@@ -44,6 +55,29 @@ namespace Device
         file.print(F(" [°], Altitude: "));
         file.print(last.alt);
         file.println(F(" [m]"));
+    }
+
+    void SDCard::write_impl(File& file, IMU_t last)
+    {
+        file.print(F("Acc: ("));
+        file.print(last.acc.x);
+        file.print(F(", "));
+        file.print(last.acc.y);
+        file.print(F(", "));
+        file.print(last.acc.z);
+        file.print(F("), Gyro: ("));
+        file.print(last.gyro.x);
+        file.print(F(", "));
+        file.print(last.gyro.y);
+        file.print(F(", "));
+        file.print(last.gyro.z);
+        file.print(F("), Mag: ("));
+        file.print(last.mag.x);
+        file.print(F(", "));
+        file.print(last.mag.y);
+        file.print(F(", "));
+        file.print(last.mag.z);
+        file.println(F(")"));
     }
 
 }  // namespace Device

--- a/src/device/sd_card.cpp
+++ b/src/device/sd_card.cpp
@@ -22,4 +22,15 @@ namespace Device
         return true;
     }
 
+    void SDCard::write_impl(File& file, BaroThermoHygrometer_t last)
+    {
+        file.print(F("Pressure: "));
+        file.print(last.pressure);
+        file.print(F(" [hPa], Temperature: "));
+        file.print(last.temperature);
+        file.print(F(" [°C], Humidity: "));
+        file.print(last.humidity);
+        file.println(F(" [%]"));
+    }
+
 }  // namespace Device

--- a/src/device/sd_card.hpp
+++ b/src/device/sd_card.hpp
@@ -23,6 +23,10 @@ namespace Device
         template <class Head, class... Args>
         static void write_impl(File& file, Head head, Args... args);
 
+        static void write_impl(File& file, coordinate last);
+        template <class... Args>
+        static void write_impl(File& file, coordinate head, Args... args);
+
         static void write_impl(File& file, BaroThermoHygrometer_t last);
         template <class... Args>
         static void write_impl(File& file, BaroThermoHygrometer_t head, Args... args);
@@ -30,6 +34,10 @@ namespace Device
         static void write_impl(File& file, GPS_t last);
         template <class... Args>
         static void write_impl(File& file, GPS_t head, Args... args);
+
+        static void write_impl(File& file, IMU_t last);
+        template <class... Args>
+        static void write_impl(File& file, IMU_t head, Args... args);
     };
 
     template <class... Args>
@@ -64,6 +72,19 @@ namespace Device
     }
 
     template <class... Args>
+    void SDCard::write_impl(File& file, coordinate head, Args... args)
+    {
+        file.print(F("("));
+        file.print(head.x);
+        file.print(F(", "));
+        file.print(head.y);
+        file.print(F(", "));
+        file.print(head.z);
+        file.print(F(") "));
+        write_impl(file, args...);
+    }
+
+    template <class... Args>
     void SDCard::write_impl(File& file, BaroThermoHygrometer_t head, Args... args)
     {
         file.print(F("Pressure: "));
@@ -88,6 +109,31 @@ namespace Device
         file.print(F(" [°], Altitude: "));
         file.print(head.alt);
         file.print(F(" [m] "));
+        write_impl(file, args...);
+    }
+
+    template <class... Args>
+    void SDCard::write_impl(File& file, IMU_t head, Args... args)
+    {
+        file.print(F("Acc: ("));
+        file.print(head.acc.x);
+        file.print(F(", "));
+        file.print(head.acc.y);
+        file.print(F(", "));
+        file.print(head.acc.z);
+        file.print(F("), Gyro: ("));
+        file.print(head.gyro.x);
+        file.print(F(", "));
+        file.print(head.gyro.y);
+        file.print(F(", "));
+        file.print(head.gyro.z);
+        file.print(F("), Mag: ("));
+        file.print(head.mag.x);
+        file.print(F(", "));
+        file.print(head.mag.y);
+        file.print(F(", "));
+        file.print(head.mag.z);
+        file.print(F(") "));
         write_impl(file, args...);
     }
 

--- a/src/device/sd_card.hpp
+++ b/src/device/sd_card.hpp
@@ -22,6 +22,10 @@ namespace Device
         static void write_impl(File& file, Last last);
         template <class Head, class... Args>
         static void write_impl(File& file, Head head, Args... args);
+
+        static void write_impl(File& file, BaroThermoHygrometer_t last);
+        template <class... Args>
+        static void write_impl(File& file, BaroThermoHygrometer_t head, Args... args);
     };
 
     template <class... Args>
@@ -52,6 +56,19 @@ namespace Device
     {
         file.print(head);
         file.print(" ");
+        write_impl(file, args...);
+    }
+
+    template <class... Args>
+    void SDCard::write_impl(File& file, BaroThermoHygrometer_t head, Args... args)
+    {
+        file.print(F("Pressure: "));
+        file.print(head.pressure);
+        file.print(F(" [hPa], Temperature: "));
+        file.print(head.temperature);
+        file.print(F(" [°C], Humidity: "));
+        file.print(head.humidity);
+        file.println(F(" [%] "));
         write_impl(file, args...);
     }
 

--- a/src/device/sd_card.hpp
+++ b/src/device/sd_card.hpp
@@ -26,6 +26,10 @@ namespace Device
         static void write_impl(File& file, BaroThermoHygrometer_t last);
         template <class... Args>
         static void write_impl(File& file, BaroThermoHygrometer_t head, Args... args);
+
+        static void write_impl(File& file, GPS_t last);
+        template <class... Args>
+        static void write_impl(File& file, GPS_t head, Args... args);
     };
 
     template <class... Args>
@@ -68,7 +72,22 @@ namespace Device
         file.print(head.temperature);
         file.print(F(" [°C], Humidity: "));
         file.print(head.humidity);
-        file.println(F(" [%] "));
+        file.print(F(" [%] "));
+        write_impl(file, args...);
+    }
+
+    template <class... Args>
+    void SDCard::write_impl(File& file, GPS_t head, Args... args)
+    {
+        file.print(F("Time: "));
+        file.print(head.time);
+        file.print(F(" [s], Latitude: "));
+        file.print(head.lat);
+        file.print(F(" [°], Longitude: "));
+        file.print(head.lon);
+        file.print(F(" [°], Altitude: "));
+        file.print(head.alt);
+        file.print(F(" [m] "));
         write_impl(file, args...);
     }
 

--- a/src/utility/printer.hpp
+++ b/src/utility/printer.hpp
@@ -3,6 +3,7 @@
 #include <Arduino.h>
 
 #include "../device/baro_thermo_hygrometer.hpp"
+#include "../device/gps_receiver.hpp"
 
 namespace Utility
 {
@@ -25,6 +26,10 @@ namespace Utility
         static void print_impl(Device::BaroThermoHygrometer_t last);
         template <class... Args>
         static void print_impl(Device::BaroThermoHygrometer_t head, Args... args);
+
+        static void print_impl(Device::GPS_t last);
+        template <class... Args>
+        static void print_impl(Device::GPS_t head, Args... args);
     };
 
     template <class... Args>
@@ -68,7 +73,35 @@ namespace Utility
         Serial.print(head.temperature);
         Serial.print(F(" [°C], Humidity: "));
         Serial.print(head.humidity);
-        Serial.println(F(" [%] "));
+        Serial.print(F(" [%] "));
+        print_impl(args...);
+    }
+
+    inline void Printer::print_impl(Device::GPS_t last)
+    {
+        Serial.print(F("Time: "));
+        Serial.print(last.time);
+        Serial.print(F(" [s], Latitude: "));
+        Serial.print(last.lat);
+        Serial.print(F(" [°], Longitude: "));
+        Serial.print(last.lon);
+        Serial.print(F(" [°], Altitude: "));
+        Serial.print(last.alt);
+        Serial.println(F(" [m]"));
+    }
+
+    template <class... Args>
+    void Printer::print_impl(Device::GPS_t head, Args... args)
+    {
+        Serial.print(F("Time: "));
+        Serial.print(head.time);
+        Serial.print(F(" [s], Latitude: "));
+        Serial.print(head.lat);
+        Serial.print(F(" [°], Longitude: "));
+        Serial.print(head.lon);
+        Serial.print(F(" [°], Altitude: "));
+        Serial.print(head.alt);
+        Serial.print(F(" [m] "));
         print_impl(args...);
     }
 

--- a/src/utility/printer.hpp
+++ b/src/utility/printer.hpp
@@ -2,6 +2,8 @@
 
 #include <Arduino.h>
 
+#include "../device/baro_thermo_hygrometer.hpp"
+
 namespace Utility
 {
 
@@ -19,6 +21,10 @@ namespace Utility
         static void print_impl(Last last);
         template <class Head, class... Args>
         static void print_impl(Head head, Args... args);
+
+        static void print_impl(Device::BaroThermoHygrometer_t last);
+        template <class... Args>
+        static void print_impl(Device::BaroThermoHygrometer_t head, Args... args);
     };
 
     template <class... Args>
@@ -39,6 +45,30 @@ namespace Utility
     {
         Serial.print(head);
         Serial.print(F(" "));
+        print_impl(args...);
+    }
+
+    inline void Printer::print_impl(Device::BaroThermoHygrometer_t last)
+    {
+        Serial.print(F("Pressure: "));
+        Serial.print(last.pressure);
+        Serial.print(F(" [hPa], Temperature: "));
+        Serial.print(last.temperature);
+        Serial.print(F(" [°C], Humidity: "));
+        Serial.print(last.humidity);
+        Serial.println(F(" [%]"));
+    }
+
+    template <class... Args>
+    void Printer::print_impl(Device::BaroThermoHygrometer_t head, Args... args)
+    {
+        Serial.print(F("Pressure: "));
+        Serial.print(head.pressure);
+        Serial.print(F(" [hPa], Temperature: "));
+        Serial.print(head.temperature);
+        Serial.print(F(" [°C], Humidity: "));
+        Serial.print(head.humidity);
+        Serial.println(F(" [%] "));
         print_impl(args...);
     }
 

--- a/src/utility/printer.hpp
+++ b/src/utility/printer.hpp
@@ -4,6 +4,7 @@
 
 #include "../device/baro_thermo_hygrometer.hpp"
 #include "../device/gps_receiver.hpp"
+#include "../device/imu.hpp"
 
 namespace Utility
 {
@@ -23,6 +24,10 @@ namespace Utility
         template <class Head, class... Args>
         static void print_impl(Head head, Args... args);
 
+        static void print_impl(Device::coordinate last);
+        template <class... Args>
+        static void print_impl(Device::coordinate head, Args... args);
+
         static void print_impl(Device::BaroThermoHygrometer_t last);
         template <class... Args>
         static void print_impl(Device::BaroThermoHygrometer_t head, Args... args);
@@ -30,6 +35,10 @@ namespace Utility
         static void print_impl(Device::GPS_t last);
         template <class... Args>
         static void print_impl(Device::GPS_t head, Args... args);
+
+        static void print_impl(Device::IMU_t last);
+        template <class... Args>
+        static void print_impl(Device::IMU_t head, Args... args);
     };
 
     template <class... Args>
@@ -50,6 +59,30 @@ namespace Utility
     {
         Serial.print(head);
         Serial.print(F(" "));
+        print_impl(args...);
+    }
+
+    inline void Printer::print_impl(Device::coordinate last)
+    {
+        Serial.print(F("("));
+        Serial.print(last.x);
+        Serial.print(F(", "));
+        Serial.print(last.y);
+        Serial.print(F(", "));
+        Serial.print(last.z);
+        Serial.println(F(")"));
+    }
+
+    template <class... Args>
+    void Printer::print_impl(Device::coordinate head, Args... args)
+    {
+        Serial.print(F("("));
+        Serial.print(head.x);
+        Serial.print(F(", "));
+        Serial.print(head.y);
+        Serial.print(F(", "));
+        Serial.print(head.z);
+        Serial.print(F(") "));
         print_impl(args...);
     }
 
@@ -102,6 +135,54 @@ namespace Utility
         Serial.print(F(" [°], Altitude: "));
         Serial.print(head.alt);
         Serial.print(F(" [m] "));
+        print_impl(args...);
+    }
+
+    inline void Printer::print_impl(Device::IMU_t last)
+    {
+        Serial.print(F("Acc: ("));
+        Serial.print(last.acc.x);
+        Serial.print(F(", "));
+        Serial.print(last.acc.y);
+        Serial.print(F(", "));
+        Serial.print(last.acc.z);
+        Serial.print(F("), Gyro: ("));
+        Serial.print(last.gyro.x);
+        Serial.print(F(", "));
+        Serial.print(last.gyro.y);
+        Serial.print(F(", "));
+        Serial.print(last.gyro.z);
+        Serial.print(F("), Mag: ("));
+        Serial.print(last.mag.x);
+        Serial.print(F(", "));
+        Serial.print(last.mag.y);
+        Serial.print(F(", "));
+        Serial.print(last.mag.z);
+        Serial.println(F(")"));
+    }
+
+    template <class... Args>
+    void Printer::print_impl(Device::IMU_t head, Args... args)
+    {
+        Serial.print(F("Acc: ("));
+        Serial.print(head.acc.x);
+        Serial.print(F(", "));
+        Serial.print(head.acc.y);
+        Serial.print(F(", "));
+        Serial.print(head.acc.z);
+        Serial.print(F("), Gyro: ("));
+        Serial.print(head.gyro.x);
+        Serial.print(F(", "));
+        Serial.print(head.gyro.y);
+        Serial.print(F(", "));
+        Serial.print(head.gyro.z);
+        Serial.print(F("), Mag: ("));
+        Serial.print(head.mag.x);
+        Serial.print(F(", "));
+        Serial.print(head.mag.y);
+        Serial.print(F(", "));
+        Serial.print(head.mag.z);
+        Serial.print(F(") "));
         print_impl(args...);
     }
 


### PR DESCRIPTION
`print`関数で `coordinate` `BaroThermoHygrometer_t` `GPS_t` `IMU_t` の型を取れるようにした。これによりより直感的に出力ができる。なお，これらは `logger` でもそのまま用いることができる。