### PR TITLE
const Stringからconst char*へのcastとabs()関数の使い方修正

### DIFF
--- a/src/device/camera.cpp
+++ b/src/device/camera.cpp
@@ -121,7 +121,7 @@ namespace Device
         }
 
         // Save the image to SD card
-        outFile = SD.open(file_name, O_WRITE | O_CREAT | O_TRUNC);
+        outFile = SD.open(file_name.c_str(), O_WRITE | O_CREAT | O_TRUNC);
         if (!outFile) {
             Utility::logger.error(F("[Camera] Failed to open file"), file_name);
             return false;

--- a/src/device/microphone.cpp
+++ b/src/device/microphone.cpp
@@ -23,7 +23,7 @@ namespace Device
     {
         uint32_t sum = 0;
         for (int8_t i = 0; i < sampling_num_; ++i) {
-            uint32_t value = abs(analogRead(output_pin_) - median_);
+            uint32_t value = abs((int32_t)(analogRead(output_pin_) - median_));
             sum += value;
         }
         uint8_t average = sum / sampling_num_;


### PR DESCRIPTION
- const Stringの型からconst char*の型に明示的に変換するように修正
- abs()関数の引数はuint32_tが厳密には使えないので修正