### PR TITLE
[update] I2C通信の際にWireしか指定できなかった箇所を修正

### DIFF
--- a/src/device/baro_thermo_hygrometer.hpp
+++ b/src/device/baro_thermo_hygrometer.hpp
@@ -21,7 +21,7 @@ namespace Device
         BaroThermoHygrometer();
         ~BaroThermoHygrometer() = default;
 
-        void init();
+        void init(TwoWire* i2c = &Wire);
         BaroThermoHygrometer_t read();
 
       private:

--- a/src/device/imu.cpp
+++ b/src/device/imu.cpp
@@ -17,80 +17,82 @@ namespace Device
     {
     }
 
-    void IMU::init()
+    void IMU::init(TwoWire* i2c)
     {
         Utility::logger.info(F("[IMU] Initializing..."));
 
-        Wire.beginTransmission(IMU_ADDR_ACCL);
-        Wire.write(0x0F);  // Select PMU_Range register
-        Wire.write(0x03);  // Range = +/- 2g
-        Wire.endTransmission();
+        i2c_ = i2c;
+        
+        i2c_->beginTransmission(IMU_ADDR_ACCL);
+        i2c_->write(0x0F);  // Select PMU_Range register
+        i2c_->write(0x03);  // Range = +/- 2g
+        i2c_->endTransmission();
         delay(100);
 
-        Wire.beginTransmission(IMU_ADDR_ACCL);
-        Wire.write(0x10);  // Select PMU_BW register
-        Wire.write(0x08);  // Bandwidth = 7.81 Hz
-        Wire.endTransmission();
+        i2c_->beginTransmission(IMU_ADDR_ACCL);
+        i2c_->write(0x10);  // Select PMU_BW register
+        i2c_->write(0x08);  // Bandwidth = 7.81 Hz
+        i2c_->endTransmission();
         delay(100);
 
-        Wire.beginTransmission(IMU_ADDR_ACCL);
-        Wire.write(0x11);  // Select PMU_LPW register
-        Wire.write(0x00);  // Normal mode, Sleep duration = 0.5ms
-        Wire.endTransmission();
+        i2c_->beginTransmission(IMU_ADDR_ACCL);
+        i2c_->write(0x11);  // Select PMU_LPW register
+        i2c_->write(0x00);  // Normal mode, Sleep duration = 0.5ms
+        i2c_->endTransmission();
         delay(100);
 
-        Wire.beginTransmission(IMU_ADDR_GYRO);
-        Wire.write(0x0F);  // Select Range register
-        Wire.write(0x04);  // Full scale = +/- 125 degree/s
-        Wire.endTransmission();
+        i2c_->beginTransmission(IMU_ADDR_GYRO);
+        i2c_->write(0x0F);  // Select Range register
+        i2c_->write(0x04);  // Full scale = +/- 125 degree/s
+        i2c_->endTransmission();
         delay(100);
 
-        Wire.beginTransmission(IMU_ADDR_GYRO);
-        Wire.write(0x10);  // Select Bandwidth register
-        Wire.write(0x07);  // ODR = 100 Hz
-        Wire.endTransmission();
+        i2c_->beginTransmission(IMU_ADDR_GYRO);
+        i2c_->write(0x10);  // Select Bandwidth register
+        i2c_->write(0x07);  // ODR = 100 Hz
+        i2c_->endTransmission();
         delay(100);
 
-        Wire.beginTransmission(IMU_ADDR_GYRO);
-        Wire.write(0x11);  // Select LPM1 register
-        Wire.write(0x00);  // Normal mode, Sleep duration = 2ms
-        Wire.endTransmission();
+        i2c_->beginTransmission(IMU_ADDR_GYRO);
+        i2c_->write(0x11);  // Select LPM1 register
+        i2c_->write(0x00);  // Normal mode, Sleep duration = 2ms
+        i2c_->endTransmission();
         delay(100);
 
-        Wire.beginTransmission(IMU_ADDR_MAG);
-        Wire.write(0x4B);  // Select Mag register
-        Wire.write(0x83);  // Soft reset
-        Wire.endTransmission();
+        i2c_->beginTransmission(IMU_ADDR_MAG);
+        i2c_->write(0x4B);  // Select Mag register
+        i2c_->write(0x83);  // Soft reset
+        i2c_->endTransmission();
         delay(100);
 
-        Wire.beginTransmission(IMU_ADDR_MAG);
-        Wire.write(0x4B);  // Select Mag register
-        Wire.write(0x01);  // Soft reset
-        Wire.endTransmission();
+        i2c_->beginTransmission(IMU_ADDR_MAG);
+        i2c_->write(0x4B);  // Select Mag register
+        i2c_->write(0x01);  // Soft reset
+        i2c_->endTransmission();
         delay(100);
 
-        Wire.beginTransmission(IMU_ADDR_MAG);
-        Wire.write(0x4C);  // Select Mag register
-        Wire.write(0x00);  // Normal Mode, ODR = 10 Hz
-        Wire.endTransmission();
+        i2c_->beginTransmission(IMU_ADDR_MAG);
+        i2c_->write(0x4C);  // Select Mag register
+        i2c_->write(0x00);  // Normal Mode, ODR = 10 Hz
+        i2c_->endTransmission();
         delay(100);
 
-        Wire.beginTransmission(IMU_ADDR_MAG);
-        Wire.write(0x4E);  // Select Mag register
-        Wire.write(0x84);  // X, Y, Z-Axis enabled
-        Wire.endTransmission();
+        i2c_->beginTransmission(IMU_ADDR_MAG);
+        i2c_->write(0x4E);  // Select Mag register
+        i2c_->write(0x84);  // X, Y, Z-Axis enabled
+        i2c_->endTransmission();
         delay(100);
 
-        Wire.beginTransmission(IMU_ADDR_MAG);
-        Wire.write(0x51);  // Select Mag register
-        Wire.write(0x04);  // No. of Repetitions for X-Y Axis = 9
-        Wire.endTransmission();
+        i2c_->beginTransmission(IMU_ADDR_MAG);
+        i2c_->write(0x51);  // Select Mag register
+        i2c_->write(0x04);  // No. of Repetitions for X-Y Axis = 9
+        i2c_->endTransmission();
         delay(100);
 
-        Wire.beginTransmission(IMU_ADDR_MAG);
-        Wire.write(0x52);  // Select Mag register
-        Wire.write(0x16);  // No. of Repetitions for Z-Axis = 15
-        Wire.endTransmission();
+        i2c_->beginTransmission(IMU_ADDR_MAG);
+        i2c_->write(0x52);  // Select Mag register
+        i2c_->write(0x16);  // No. of Repetitions for Z-Axis = 15
+        i2c_->endTransmission();
         delay(100);
 
         Utility::logger.info(F("[IMU] Initialized"));
@@ -107,13 +109,13 @@ namespace Device
 
         uint8_t data[6];
         for (uint8_t i = 0; i < 6; i++) {
-            Wire.beginTransmission(IMU_ADDR_ACCL);
-            Wire.write((2 + i));  // Select data register
-            Wire.endTransmission();
-            Wire.requestFrom(IMU_ADDR_ACCL, 1);  // Request 1 byte of data
+            i2c_->beginTransmission(IMU_ADDR_ACCL);
+            i2c_->write((2 + i));  // Select data register
+            i2c_->endTransmission();
+            i2c_->requestFrom(IMU_ADDR_ACCL, 1);  // Request 1 byte of data
             // Read 6 bytes of data
-            if (Wire.available() == 1) {
-                data[i] = Wire.read();
+            if (i2c_->available() == 1) {
+                data[i] = i2c_->read();
             }
         }
         // Convert the data to 12-bits
@@ -142,13 +144,13 @@ namespace Device
 
         uint8_t data[6];
         for (uint8_t i = 0; i < 6; i++) {
-            Wire.beginTransmission(IMU_ADDR_GYRO);
-            Wire.write((2 + i));  // Select data register
-            Wire.endTransmission();
-            Wire.requestFrom(IMU_ADDR_GYRO, 1);  // Request 1 byte of data
+            i2c_->beginTransmission(IMU_ADDR_GYRO);
+            i2c_->write((2 + i));  // Select data register
+            i2c_->endTransmission();
+            i2c_->requestFrom(IMU_ADDR_GYRO, 1);  // Request 1 byte of data
             // Read 6 bytes of data
-            if (Wire.available() == 1) {
-                data[i] = Wire.read();
+            if (i2c_->available() == 1) {
+                data[i] = i2c_->read();
             }
         }
         // Convert the data
@@ -177,13 +179,13 @@ namespace Device
 
         uint8_t data[8];
         for (uint8_t i = 0; i < 8; i++) {
-            Wire.beginTransmission(IMU_ADDR_MAG);
-            Wire.write((0x42 + i));  // Select data register
-            Wire.endTransmission();
-            Wire.requestFrom(IMU_ADDR_MAG, 1);  // Request 1 byte of data
+            i2c_->beginTransmission(IMU_ADDR_MAG);
+            i2c_->write((0x42 + i));  // Select data register
+            i2c_->endTransmission();
+            i2c_->requestFrom(IMU_ADDR_MAG, 1);  // Request 1 byte of data
             // Read 8 bytes of data
-            if (Wire.available() == 1) {
-                data[i] = Wire.read();
+            if (i2c_->available() == 1) {
+                data[i] = i2c_->read();
             }
         }
         // Convert the data

--- a/src/device/imu.hpp
+++ b/src/device/imu.hpp
@@ -28,7 +28,7 @@ namespace Device
         IMU();
         ~IMU() = default;
 
-        void init();
+        void init(TwoWire* i2c = &Wire);
         IMU_t read() override;
         coordinate readAccel() const;
         coordinate readGyro() const;

--- a/src/device/sensor_base.hpp
+++ b/src/device/sensor_base.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Arduino.h>
+#include <Wire.h>
 
 namespace Device
 {
@@ -12,6 +13,8 @@ namespace Device
 
         SensorBase();
         ~SensorBase() = default;
+
+        TwoWire* i2c_ = NULL;
 
       public:
 


### PR DESCRIPTION
## 詳細
- 今までのライブラリだとI2C通信を行いたい場合はデフォルトで`Wire`が選択されていたが、I2Cポートが複数ある場合に拡張できないので、`init()`関数でI2Cポートを設定できるようにした。
- 互換性を担保し、引数がない場合は今まで通りの挙動になるようにも配慮